### PR TITLE
Use a forked version of `postcss-csso`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fullhuman/postcss-purgecss": "^5",
         "autoprefixer": "^10",
         "postcss-color-function": "^4",
-        "postcss-csso": "^6",
+        "postcss-csso": "lookback/postcss-csso#fix/csso-container-queries",
         "postcss-import": "^15",
         "postcss-nested": "^6",
         "tailwindcss": "=2.0.2"
@@ -2017,8 +2017,8 @@
     },
     "node_modules/postcss-csso": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-csso/-/postcss-csso-6.0.1.tgz",
-      "integrity": "sha512-ZV4yEziMrx6CEiqabGLrDva0pMD7Fbw7yP+LzJvaynM4OJgTssGN6dHiMsJMJdpmNaLJltXVLsrb/5sxbFa8sA==",
+      "resolved": "git+ssh://git@github.com/lookback/postcss-csso.git#6cb7497ebb1c3788e2304267ac30b244f7809947",
+      "license": "MIT",
       "dependencies": {
         "csso": "^5.0.5"
       },
@@ -4560,9 +4560,8 @@
       }
     },
     "postcss-csso": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-csso/-/postcss-csso-6.0.1.tgz",
-      "integrity": "sha512-ZV4yEziMrx6CEiqabGLrDva0pMD7Fbw7yP+LzJvaynM4OJgTssGN6dHiMsJMJdpmNaLJltXVLsrb/5sxbFa8sA==",
+      "version": "git+ssh://git@github.com/lookback/postcss-csso.git#6cb7497ebb1c3788e2304267ac30b244f7809947",
+      "from": "postcss-csso@lookback/postcss-csso#fix/csso-container-queries",
       "requires": {
         "csso": "^5.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@fullhuman/postcss-purgecss": "^5",
     "autoprefixer": "^10",
     "postcss-color-function": "^4",
-    "postcss-csso": "^6",
+    "postcss-csso": "lookback/postcss-csso#fix/csso-container-queries",
     "postcss-import": "^15",
     "postcss-nested": "^6",
     "tailwindcss": "=2.0.2"


### PR DESCRIPTION
The version on NPM does not support `@container` queries. There was a [PR][0] proposed that added this, but that has since been closed. However, the PR did actually resolve the issue so I forked it into lookback/postcss-csso and pointed the dependency directly to the git repo here.

[0]: https://github.com/lahmatiy/postcss-csso/pull/28